### PR TITLE
SMOK-44691 | Avoid system QT to ensure compatibility

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -123,6 +123,7 @@ class ShotgunEngine(Engine):
         t = tk_shotgun.Task(self, callback)
         
         # start up our QApp now
+        QtGui.QApplication.setLibraryPaths([])
         qt_application = QtGui.QApplication([])        
         qt_application.setWindowIcon(QtGui.QIcon(self.icon_256))
         self._initialize_dark_look_and_feel()


### PR DESCRIPTION
This removes the system Qt library paths before the initialization of the UI, otherwise, we might have an error when starting something from the website from a system having an incompatible Qt version.

![launch](https://cloud.githubusercontent.com/assets/6785406/26462535/358277ac-414f-11e7-8536-fa32c666c8a9.png)

