### PR TITLE
SG-3081 - Add High-DPI support to the FPTR desktop app

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -179,7 +179,6 @@ class ShotgunEngine(Engine):
         if tank.util.is_linux() and os.environ.get("KDE_FULL_SESSION") is not None:
             QtGui.QApplication.setLibraryPaths([])
 
-        # Enable High DPI support in Qt5 (default enabled in Qt6)
         if QtCore.qVersion()[0] == "5":
             # Enable High DPI support in Qt5 (default enabled in Qt6)
             #

--- a/engine.py
+++ b/engine.py
@@ -179,6 +179,10 @@ class ShotgunEngine(Engine):
         if tank.util.is_linux() and os.environ.get("KDE_FULL_SESSION") is not None:
             QtGui.QApplication.setLibraryPaths([])
 
+        # Enable High DPI support in Qt5 (default enabled in Qt6)
+        if QtCore.qVersion()[0] == "5":
+            QtCore.QCoreApplication.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling)
+
         # start up our QApp now
         qt_application = QtGui.QApplication([])
         qt_application.setWindowIcon(QtGui.QIcon(self.icon_256))

--- a/engine.py
+++ b/engine.py
@@ -181,7 +181,19 @@ class ShotgunEngine(Engine):
 
         # Enable High DPI support in Qt5 (default enabled in Qt6)
         if QtCore.qVersion()[0] == "5":
-            QtCore.QCoreApplication.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling)
+            # Enable High DPI support in Qt5 (default enabled in Qt6)
+            #
+            # Only enable it if none of the Qt environment variables related to
+            # High-DPI are set
+
+            if "QT_AUTO_SCREEN_SCALE_FACTOR" in os.environ:
+                pass
+            elif "QT_SCALE_FACTOR" in os.environ:
+                pass
+            elif "QT_SCREEN_SCALE_FACTORS" in os.environ:
+                pass
+            else:
+                QtCore.QCoreApplication.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling)
 
         # start up our QApp now
         qt_application = QtGui.QApplication([])


### PR DESCRIPTION
Enable the `AA_EnableHighDpiScaling` property before instantiating the _QApplication_.

Relates to:

- shotgunsoftware/tk-shell#32
- shotgunsoftware/tk-desktop#176
- shotgunsoftware/tk-framework-desktopstartup#126
